### PR TITLE
styled-components v4: Re-add types for React Native

### DIFF
--- a/definitions/npm/styled-components_v4.x.x/flow_v0.92.0-/styled-components_v4.x.x.js
+++ b/definitions/npm/styled-components_v4.x.x/flow_v0.92.0-/styled-components_v4.x.x.js
@@ -248,7 +248,7 @@ declare module 'styled-components' {
   declare type ConvenientShorthands = $ObjMap<
     BuiltinElementInstances,
     <V>(V) =>
-      // TODO: Figre out how to add support for `attrs` API here
+      // TODO: Figure out how to add support for `attrs` API here
       // TODO: Would be nice if we could find a way to use `StyledFactory` here, but I am too dumb to figure it out.
       <P, Th>(string[], ...Interpolation<P & ThemeProps<Th>>[]) => StyledComponent<P, Th, V>
    >
@@ -263,161 +263,169 @@ declare module 'styled-components' {
 
 
 
-// declare module 'styled-components/native' {
+declare module 'styled-components/native' {
 
-//   declare export type Interpolation =
-//                                     | (<P: {}>(executionContext: P) => string)
-//                                     | CSSRules
-//                                     | KeyFrames
-//                                     | string
-//                                     | number
+  declare export type Interpolation<P> =
+                                       | ((executionContext: P) => Interpolation<any>)
+                                       | CSSRules
+                                       | KeyFrames
+                                       | string
+                                       | number
 
+  // Should this be `mixed` perhaps?
+  declare export type CSSRules = Interpolation<any>[]
 
-//   declare export type CSSRules = Interpolation[]
+  // This is not exported on purpose, since it's an implementation detail
+  declare type TaggedTemplateLiteral<I, R> = (strings: string[], ...interpolations: Interpolation<I>[]) => R
 
-//   // This is not exported on purpose, since it's an implementation detail
-//   declare type TaggedTemplateLiteral<R> = (strings : string[], ...interpolations : Interpolation[]) => R
+  declare export type CSSConstructor = TaggedTemplateLiteral<any, CSSRules>
+  declare export type KeyFramesConstructor = TaggedTemplateLiteral<any, KeyFrames>
+  declare export type CreateGlobalStyleConstructor = TaggedTemplateLiteral<any, React$ComponentType<*>>
 
-//   declare export type CSSConstructor = TaggedTemplateLiteral<CSSRules>
-//   declare export type KeyFramesConstructor = TaggedTemplateLiteral<KeyFrames>
-//   declare export type CreateGlobalStyleConstructor = TaggedTemplateLiteral<React$ComponentType<*>>
+  declare interface Tag<T> {
+    styleTag: HTMLStyleElement | null;
+    getIds(): string[];
+    hasNameForId(id: string, name: string): boolean;
+    insertMarker(id: string): T;
+    insertRules(id: string, cssRules: string[], name: ?string): void;
+    removeRules(id: string): void;
+    css(): string;
+    toHTML(additionalAttrs: ?string): string;
+    toElement(): React$Element<*>;
+    clone(): Tag<T>;
+    sealed: boolean;
+  }
 
-//   declare interface Tag<T> {
-//     styleTag: HTMLStyleElement | null;
-//     getIds(): string[];
-//     hasNameForId(id: string, name: string): boolean;
-//     insertMarker(id: string): T;
-//     insertRules(id: string, cssRules: string[], name: ?string): void;
-//     removeRules(id: string): void;
-//     css(): string;
-//     toHTML(additionalAttrs: ?string): string;
-//     toElement(): React$Element<*>;
-//     clone(): Tag<T>;
-//     sealed: boolean;
-//   }
+  // The `any`/weak types in here all come from `styled-components` directly, since those definitions were just copied over
+  declare export class StyleSheet {
+    static get master() : StyleSheet;
+    static get instance() : StyleSheet;
+    static reset(forceServer? : boolean) : void;
 
-//   // The `any`/weak types in here all come from `styled-components` directly, since those definitions were just copied over
-//   declare export class StyleSheet {
-//     static get master() : StyleSheet;
-//     static get instance() : StyleSheet;
-//     static reset(forceServer? : boolean) : void;
+    id : number;
+    forceServer : boolean;
+    target : ?HTMLElement;
+    tagMap : {[string]: Tag<any>}; // eslint-disable-line flowtype/no-weak-types
+    deferred: { [string]: string[] | void };
+    rehydratedNames: { [string]: boolean };
+    ignoreRehydratedNames: { [string]: boolean };
+    tags: Tag<any>[]; // eslint-disable-line flowtype/no-weak-types
+    importRuleTag: Tag<any>; // eslint-disable-line flowtype/no-weak-types
+    capacity: number;
+    clones: StyleSheet[];
 
-//     id : number;
-//     forceServer : boolean;
-//     target : ?HTMLElement;
-//     tagMap : {[string]: Tag<any>}; // eslint-disable-line flowtype/no-weak-types
-//     deferred: { [string]: string[] | void };
-//     rehydratedNames: { [string]: boolean };
-//     ignoreRehydratedNames: { [string]: boolean };
-//     tags: Tag<any>[]; // eslint-disable-line flowtype/no-weak-types
-//     importRuleTag: Tag<any>; // eslint-disable-line flowtype/no-weak-types
-//     capacity: number;
-//     clones: StyleSheet[];
+    constructor(?HTMLElement) : this;
+    rehydrate() : this;
+    clone() : StyleSheet;
+    sealAllTags() : void;
+    makeTag(tag : ?Tag<any>) : Tag<any>; // eslint-disable-line flowtype/no-weak-types
+    getImportRuleTag() : Tag<any>; // eslint-disable-line flowtype/no-weak-types
+    getTagForId(id : string): Tag<any>; // eslint-disable-line flowtype/no-weak-types
+    hasId(id: string) : boolean;
+    hasNameForId(id: string, name: string) : boolean;
+    deferredInject(id : string, cssRules : string[]) : void;
+    inject(id: string, cssRules : string[], name? : string) : void;
+    remove(id : string) : void;
+    toHtml() : string;
+    toReactElements() : React$ElementType[];
+  }
 
-//     constructor(?HTMLElement) : this;
-//     rehydrate() : this;
-//     clone() : StyleSheet;
-//     sealAllTags() : void;
-//     makeTag(tag : ?Tag<any>) : Tag<any>; // eslint-disable-line flowtype/no-weak-types
-//     getImportRuleTag() : Tag<any>; // eslint-disable-line flowtype/no-weak-types
-//     getTagForId(id : string): Tag<any>; // eslint-disable-line flowtype/no-weak-types
-//     hasId(id: string) : boolean;
-//     hasNameForId(id: string, name: string) : boolean;
-//     deferredInject(id : string, cssRules : string[]) : void;
-//     inject(id: string, cssRules : string[], name? : string) : void;
-//     remove(id : string) : void;
-//     toHtml() : string;
-//     toReactElements() : React$ElementType[];
-//   }
+  declare export class KeyFrames {
+    id : string;
+    name : string;
+    rules : string[];
 
-//   declare export class KeyFrames {
-//     id : string;
-//     name : string;
-//     rules : string[];
+    constructor(name : string, rules : string[]) : this;
+    inject(StyleSheet) : void;
+    toString() : string;
+    getName() : string;
+  }
 
-//     constructor(name : string, rules : string[]) : this;
-//     inject(StyleSheet) : void;
-//     toString() : string;
-//     getName() : string;
-//   }
+  // I think any is appropriate here?
+  // eslint-disable-next-line flowtype/no-weak-types
+  declare export var css : CSSConstructor;
+  declare export var keyframes : KeyFramesConstructor;
+  declare export var createGlobalStyle : CreateGlobalStyleConstructor
+  declare export var ThemeProvider: React$ComponentType<{children?: ?React$Node, theme: mixed | (mixed) => mixed}>
 
-//   // I think any is appropriate here?
-//   // eslint-disable-next-line flowtype/no-weak-types
-//   declare export type Theme = {+[string] : any}
+  // This is a bit hard to read. Not sure how to make it more readable. I think adding line-breaks makes it worse.
+  declare type ThemeProps<T> = {
+    theme: T
+  }
 
-//   declare export var css : CSSConstructor;
-//   declare export var keyframes : KeyFramesConstructor;
-//   declare export var createGlobalStyle : CreateGlobalStyleConstructor
-//   declare export var ThemeProvider : React$ComponentType<{children?: ?React$Node, theme : Theme | (Theme) => Theme}>
+  declare export function withTheme<Theme, Config: {}, Instance>(Component: React$AbstractComponent<Config, Instance>): React$AbstractComponent<$Diff<Config, ThemeProps<Theme | void>>, Instance>
 
-//   // This is a bit hard to read. Not sure how to make it more readable. I think adding line-breaks makes it worse.
-//   declare type InjectedProps = { theme : Theme | void }
-//   declare  export function withTheme<Props : {}, Component: React$ComponentType<Props>>(WrappedComponent: Component) : React$ComponentType<$Diff<React$ElementConfig<$Supertype<Component>>, InjectedProps>>;
+  declare export type StyledComponent<Props, Theme, Instance> = React$AbstractComponent<Props, Instance>
+  declare interface StyledFactory<StyleProps, OwnProps, Theme, Instance> {
+    [[call]]: TaggedTemplateLiteral<StyleProps & OwnProps & ThemeProps<Theme>, StyledComponent<StyleProps & OwnProps, Theme, Instance>>;
+    +attrs: <A: {}>(A | (OwnProps & StyleProps) => A) => React$AbstractComponent<$Diff<OwnProps & StyleProps, A>, Instance>;
+  }
 
+  declare type BuiltinElementInstances = {
+    ActivityIndicator:             React$ComponentType<{}>,
+    ActivityIndicatorIOS:          React$ComponentType<{}>,
+    ART:                           React$ComponentType<{}>,
+    Button:                        React$ComponentType<{}>,
+    DatePickerIOS:                 React$ComponentType<{}>,
+    DrawerLayoutAndroid:           React$ComponentType<{}>,
+    Image:                         React$ComponentType<{}>,
+    ImageBackground:               React$ComponentType<{}>,
+    ImageEditor:                   React$ComponentType<{}>,
+    ImageStore:                    React$ComponentType<{}>,
+    KeyboardAvoidingView:          React$ComponentType<{}>,
+    ListView:                      React$ComponentType<{}>,
+    MapView:                       React$ComponentType<{}>,
+    Modal:                         React$ComponentType<{}>,
+    NavigatorIOS:                  React$ComponentType<{}>,
+    Picker:                        React$ComponentType<{}>,
+    PickerIOS:                     React$ComponentType<{}>,
+    ProgressBarAndroid:            React$ComponentType<{}>,
+    ProgressViewIOS:               React$ComponentType<{}>,
+    ScrollView:                    React$ComponentType<{}>,
+    SegmentedControlIOS:           React$ComponentType<{}>,
+    Slider:                        React$ComponentType<{}>,
+    SliderIOS:                     React$ComponentType<{}>,
+    SnapshotViewIOS:               React$ComponentType<{}>,
+    Switch:                        React$ComponentType<{}>,
+    RecyclerViewBackedScrollView:  React$ComponentType<{}>,
+    RefreshControl:                React$ComponentType<{}>,
+    SafeAreaView:                  React$ComponentType<{}>,
+    StatusBar:                     React$ComponentType<{}>,
+    SwipeableListView:             React$ComponentType<{}>,
+    SwitchAndroid:                 React$ComponentType<{}>,
+    SwitchIOS:                     React$ComponentType<{}>,
+    TabBarIOS:                     React$ComponentType<{}>,
+    Text:                          React$ComponentType<{}>,
+    TextInput:                     React$ComponentType<{}>,
+    ToastAndroid:                  React$ComponentType<{}>,
+    ToolbarAndroid:                React$ComponentType<{}>,
+    Touchable:                     React$ComponentType<{}>,
+    TouchableHighlight:            React$ComponentType<{}>,
+    TouchableNativeFeedback:       React$ComponentType<{}>,
+    TouchableOpacity:              React$ComponentType<{}>,
+    TouchableWithoutFeedback:      React$ComponentType<{}>,
+    View:                          React$ComponentType<{}>,
+    ViewPagerAndroid:              React$ComponentType<{}>,
+    WebView:                       React$ComponentType<{}>,
+    FlatList:                      React$ComponentType<{}>,
+    SectionList:                   React$ComponentType<{}>,
+    VirtualizedList:               React$ComponentType<{}>,
+  }
 
-//   // @HACK This is a cheat to hide that the underlying type is "just a string"
-//   //       once we know of a better way, we should be able to update this accordingly.
-//   //       I don't think there _is_ a good way, currently.
-//   // @NOTE Also not too sure about the naming of this...
-//   declare export type StyledElementType<T> = T;
-//   declare export type StyledComponentType<C> = {
-//     [[call]]: TaggedTemplateLiteral<C>,
-//     +attrs: <A: {}>(attributes: A) => TaggedTemplateLiteral<React$ComponentType<$Diff<React$ElementConfig<C>, A>>>
-//   };
+  declare type BuiltinElementType<ElementName: string> = $ElementType<BuiltinElementInstances, ElementName>
 
-//   declare type StyledComponentList = {
-//     ActivityIndicator:             StyledComponentType<React$ComponentType<{}>>,
-//     ActivityIndicatorIOS:          StyledComponentType<React$ComponentType<{}>>,
-//     ART:                           StyledComponentType<React$ComponentType<{}>>,
-//     Button:                        StyledComponentType<React$ComponentType<{}>>,
-//     DatePickerIOS:                 StyledComponentType<React$ComponentType<{}>>,
-//     DrawerLayoutAndroid:           StyledComponentType<React$ComponentType<{}>>,
-//     Image:                         StyledComponentType<React$ComponentType<{}>>,
-//     ImageBackground:               StyledComponentType<React$ComponentType<{}>>,
-//     ImageEditor:                   StyledComponentType<React$ComponentType<{}>>,
-//     ImageStore:                    StyledComponentType<React$ComponentType<{}>>,
-//     KeyboardAvoidingView:          StyledComponentType<React$ComponentType<{}>>,
-//     ListView:                      StyledComponentType<React$ComponentType<{}>>,
-//     MapView:                       StyledComponentType<React$ComponentType<{}>>,
-//     Modal:                         StyledComponentType<React$ComponentType<{}>>,
-//     NavigatorIOS:                  StyledComponentType<React$ComponentType<{}>>,
-//     Picker:                        StyledComponentType<React$ComponentType<{}>>,
-//     PickerIOS:                     StyledComponentType<React$ComponentType<{}>>,
-//     ProgressBarAndroid:            StyledComponentType<React$ComponentType<{}>>,
-//     ProgressViewIOS:               StyledComponentType<React$ComponentType<{}>>,
-//     ScrollView:                    StyledComponentType<React$ComponentType<{}>>,
-//     SegmentedControlIOS:           StyledComponentType<React$ComponentType<{}>>,
-//     Slider:                        StyledComponentType<React$ComponentType<{}>>,
-//     SliderIOS:                     StyledComponentType<React$ComponentType<{}>>,
-//     SnapshotViewIOS:               StyledComponentType<React$ComponentType<{}>>,
-//     Switch:                        StyledComponentType<React$ComponentType<{}>>,
-//     RecyclerViewBackedScrollView:  StyledComponentType<React$ComponentType<{}>>,
-//     RefreshControl:                StyledComponentType<React$ComponentType<{}>>,
-//     SafeAreaView:                  StyledComponentType<React$ComponentType<{}>>,
-//     StatusBar:                     StyledComponentType<React$ComponentType<{}>>,
-//     SwipeableListView:             StyledComponentType<React$ComponentType<{}>>,
-//     SwitchAndroid:                 StyledComponentType<React$ComponentType<{}>>,
-//     SwitchIOS:                     StyledComponentType<React$ComponentType<{}>>,
-//     TabBarIOS:                     StyledComponentType<React$ComponentType<{}>>,
-//     Text:                          StyledComponentType<React$ComponentType<{}>>,
-//     TextInput:                     StyledComponentType<React$ComponentType<{}>>,
-//     ToastAndroid:                  StyledComponentType<React$ComponentType<{}>>,
-//     ToolbarAndroid:                StyledComponentType<React$ComponentType<{}>>,
-//     Touchable:                     StyledComponentType<React$ComponentType<{}>>,
-//     TouchableHighlight:            StyledComponentType<React$ComponentType<{}>>,
-//     TouchableNativeFeedback:       StyledComponentType<React$ComponentType<{}>>,
-//     TouchableOpacity:              StyledComponentType<React$ComponentType<{}>>,
-//     TouchableWithoutFeedback:      StyledComponentType<React$ComponentType<{}>>,
-//     View:                          StyledComponentType<React$ComponentType<{}>>,
-//     ViewPagerAndroid:              StyledComponentType<React$ComponentType<{}>>,
-//     WebView:                       StyledComponentType<React$ComponentType<{}>>,
-//     FlatList:                      StyledComponentType<React$ComponentType<{}>>,
-//     SectionList:                   StyledComponentType<React$ComponentType<{}>>,
-//     VirtualizedList:               StyledComponentType<React$ComponentType<{}>>,
-//   }
+  declare type ConvenientShorthands = $ObjMap<
+    BuiltinElementInstances,
+    <V>(V) =>
+      // TODO: Figure out how to add support for `attrs` API here
+      // TODO: Would be nice if we could find a way to use `StyledFactory` here, but I am too dumb to figure it out.
+      <P, Th>(string[], ...Interpolation<P & ThemeProps<Th>>[]) => StyledComponent<P, Th, V>
+   >
 
-//   declare export default StyledComponentList & {
-//     [[call]]: <S : string>(S) => $ElementType<StyledComponentList, S>,
-//     [[call]]: <P : {}, C : React$ComponentType<P>>(C) => StyledComponentType<C>
-//   };
-// }
+  declare interface Styled {
+    <P, Th, ElementName: $Keys<BuiltinElementInstances>>(ElementName): StyledFactory<P, {}, Th, BuiltinElementType<ElementName>>;
+    <SP, Th, OP: {}, C: React$ComponentType<OP>>(C): StyledFactory<SP, OP, Th, React$ComponentType<C>>;
+  }
+
+  declare export default Styled & ConvenientShorthands
+}

--- a/definitions/npm/styled-components_v4.x.x/flow_v0.92.0-/test_styled-components-native.js
+++ b/definitions/npm/styled-components_v4.x.x/flow_v0.92.0-/test_styled-components-native.js
@@ -1,0 +1,24 @@
+// @flow
+import * as React from 'react'
+// import * as ReactNative from 'react-native'
+import styled from 'styled-components/native'
+
+// Test that we can create native components
+const Text1 = styled.Text``
+const Text2 = styled('Text')``
+
+// $ExpectError - test for non-existent element
+const derp1 = styled.derp``
+
+// $ExpectError - test for non-existent element
+const derp2 = styled('derp')``
+
+// Test we don't "accidentally style" something else:
+// $ExpectError
+const derp3 = styled(null)``
+
+// $ExpectError
+const derp3 = styled({})``
+
+// $ExpectError
+const derp3 = styled(1)``


### PR DESCRIPTION
This pull request re-adds the types for React Native. I made heavy use of copy-and-paste. I also only added back types to reach the same level of definitions that previously existed. More work could be done to better support React Native, but this at least gives us feature parity with what previously existed.