### PR TITLE
styled-components: Add test for default props

### DIFF
--- a/definitions/npm/styled-components_v4.x.x/flow_v0.92.0-/test_styled-components_v4.x.x.js
+++ b/definitions/npm/styled-components_v4.x.x/flow_v0.92.0-/test_styled-components_v4.x.x.js
@@ -350,4 +350,10 @@ describe('wrapping components', () => {
     // $ExpectError - Invalid prop type
     const hello3 = <StyledHello name={3} />
   })
+
+  it('allows default props to be defined', () => {
+    StyledHello.defaultProps = {
+      name: "me"
+    }
+  })
 })


### PR DESCRIPTION
It looks like using `defaultProps` is currently failing. I haven't looked into why this is at all yet, just wanted to add a test for it to get the ball rolling.